### PR TITLE
Allow to use custom-defined statements in extended_vars

### DIFF
--- a/syntax/perl.vim
+++ b/syntax/perl.vim
@@ -255,7 +255,7 @@ endif
 syn match  perlVarPlain2	 "%[-+]"
 
 if !exists("perl_no_extended_vars")
-  syn cluster perlExpr		contains=perlStatementIndirObjWrap,perlStatementScalar,perlStatementRegexp,perlStatementNumeric,perlStatementList,perlStatementHash,perlStatementFiles,perlStatementTime,perlStatementMisc,perlVarPlain,perlVarPlain2,perlVarNotInMatches,perlVarSlash,perlVarBlock,perlVarBlock2,perlShellCommand,perlFloat,perlNumber,perlStringUnexpanded,perlString,perlQQ,perlArrow,perlBraces
+  syn cluster perlExpr		contains=perlStatementIndirObjWrap,perlStatementScalar,perlStatementRegexp,perlStatementNumeric,perlStatementList,perlStatementHash,perlStatementFiles,perlStatementTime,perlStatementMisc,perlVarPlain,perlVarPlain2,perlVarNotInMatches,perlVarSlash,perlVarBlock,perlVarBlock2,perlShellCommand,perlFloat,perlNumber,perlStringUnexpanded,perlString,perlQQ,perlArrow,perlBraces,perlCustomStatement0,perlCustomStatement1,perlCustomStatement2,perlCustomStatement3,perlCustomStatement4,perlCustomStatement5,perlCustomStatement6,perlCustomStatement7,perlCustomStatement8,perlCustomStatement9
   syn region perlArrow		matchgroup=perlArrow start="->\s*(" end=")" contains=@perlExpr nextgroup=perlVarMember,perlVarSimpleMember,perlMethod contained
   syn region perlArrow		matchgroup=perlArrow start="->\s*\[" end="\]" contains=@perlExpr nextgroup=perlVarMember,perlVarSimpleMember,perlMethod contained
   syn region perlArrow		matchgroup=perlArrow start="->\s*{" end="}" contains=@perlExpr nextgroup=perlVarMember,perlVarSimpleMember,perlMethod contained


### PR DESCRIPTION
I'd like to add several 'syn match' on per-project basis - widely used helper subs, for example.
But they are not count inside of extended vars properly.

Here is quick example:

```
        " internal functions:
        " 1. start wiht _, _then_only_lower_case
        " 2. have at least two "words" separated by _, only lower case
        syn match perlCustomStatement1  "\<\%(_[a-z0-9_]\+\)\>\%((\?\)\@="
        syn match perlCustomStatement1  "\<\%([a-z0-9]\+_[a-z0-9_]\+\)\>\%((\?\)\@="
```

Later in perl code such names are not highlighted properly:

``` perl
my %hash = %{ _get_some_hash() };
```

Proposed fix allow to define up to 10 custom syntax rules that will be highlighted properly.
